### PR TITLE
Feature/change docker scan tool

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -73,7 +73,7 @@ runs:
       env:
         REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REPOSITORY: ${{ inputs.app-name }}
-        IMAGE_TAG: ${{ env.RELEASE_VERSION }}
+        IMAGE_TAG: mock-tag
       run: |
         docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -f ${{ inputs.dockerfile-name }} \
           --build-arg GITHUB_USER_TOKEN=${{ inputs.service-github-token }} .

--- a/action.yaml
+++ b/action.yaml
@@ -80,6 +80,7 @@ runs:
         docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
     - name: Enable Image Scanning on Push
+      shell: bash
       run: |
         aws ecr put-image-scanning-configuration \
           --repository-name ${{ inputs.app-name }} \

--- a/action.yaml
+++ b/action.yaml
@@ -73,7 +73,7 @@ runs:
       env:
         REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REPOSITORY: ${{ inputs.app-name }}
-        IMAGE_TAG: mock-tag
+        IMAGE_TAG: ${{ env.RELEASE_VERSION }}
       run: |
         docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -f ${{ inputs.dockerfile-name }} \
           --build-arg GITHUB_USER_TOKEN=${{ inputs.service-github-token }} .

--- a/action.yaml
+++ b/action.yaml
@@ -79,15 +79,13 @@ runs:
           --build-arg GITHUB_USER_TOKEN=${{ inputs.service-github-token }} .
         docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: '${{ steps.login-ecr.outputs.registry }}/${{ inputs.app-name }}:${{ env.RELEASE_VERSION }}'
-        format: 'table'
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        severity: 'CRITICAL,HIGH'
-        exit-code: '0'
+    - name: Enable Image Scanning on Push
+      run: |
+        aws ecr put-image-scanning-configuration \
+          --repository-name ${{ inputs.app-name }} \
+          --image-scanning-configuration scanOnPush=true \
+          --region ${{ inputs.aws-region }}
+
 
     - name: Kustomize step
       uses: LerianStudio/github-actions-kustomize-argocd-manifests@main

--- a/action.yaml
+++ b/action.yaml
@@ -59,14 +59,14 @@ runs:
     - name: Get git repository informations
       uses: LerianStudio/github-actions-git-informations@main
 
-    # - name: Run Trivy vulnerability scanner in repo mode
-    #   uses: aquasecurity/trivy-action@master
-    #   with:
-    #     scan-type: 'fs'
-    #     format: 'table'
-    #     ignore-unfixed: true
-    #     severity: 'CRITICAL,HIGH'
-    #     exit-code: '0'
+    - name: Run Trivy vulnerability scanner in repo mode
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'fs'
+        format: 'table'
+        ignore-unfixed: true
+        severity: 'CRITICAL,HIGH'
+        exit-code: '0'
 
     - name: Build, tag, and push docker image to Amazon ECR
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -59,14 +59,14 @@ runs:
     - name: Get git repository informations
       uses: LerianStudio/github-actions-git-informations@main
 
-    - name: Run Trivy vulnerability scanner in repo mode
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        format: 'table'
-        ignore-unfixed: true
-        severity: 'CRITICAL,HIGH'
-        exit-code: '0'
+    # - name: Run Trivy vulnerability scanner in repo mode
+    #   uses: aquasecurity/trivy-action@master
+    #   with:
+    #     scan-type: 'fs'
+    #     format: 'table'
+    #     ignore-unfixed: true
+    #     severity: 'CRITICAL,HIGH'
+    #     exit-code: '0'
 
     - name: Build, tag, and push docker image to Amazon ECR
       shell: bash


### PR DESCRIPTION
This commit replaces the Trivy tool's docker image scanner with the native AWS ECR scanner as directed by Taura Security